### PR TITLE
Bugfix: Removed excess spacing at headers of new footer pages

### DIFF
--- a/src/styles/Reports.css
+++ b/src/styles/Reports.css
@@ -4,8 +4,8 @@ h3
 	color: var(--brown);
 }
 
-h2 {
-	
+.Reports h2 {
+
 	margin-top: 6em;
 }
 
@@ -18,7 +18,7 @@ h2 {
 {
 	display: grid;
 	grid-template-columns: 55vw 30vw;
-	
+
 	/* Single column o narrow screens */
 	@media (max-width: 1024px) {
 		display: block;


### PR DESCRIPTION
Reduced scope of H2 style element for Reports page 'cause it was for some reason being applied to the new footer pages. not adding new spacing 'cause we're way too close to the deadline. Will add before we do the poster screenshots.